### PR TITLE
Revert "Add missing file so tests pass on linux"

### DIFF
--- a/ciphers_gcm.go
+++ b/ciphers_gcm.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !openssl_pre_1.0
+
 package openssl
 
 // #include <openssl/evp.h>

--- a/ciphers_test.go
+++ b/ciphers_test.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // +build !darwin
+// +build !openssl_pre_1.0
 
 package openssl
 


### PR DESCRIPTION
This reverts commit afcd0c1b2ce91ba6b56c492e85b160c706030605.

Adding cipers_gcm.go made it impossible for this package to compile
against OpenSSL 0.9.8 (which is the version installed on SLES 11, one of
the BI Connector's supported platforms).

This change was made just so the unit tests would pass on Linux. Discussed with @deafgoat, and we decided to revert the change so that we can successfully release the BI Connector on SLES 11.

We probably do want to have all the 10gen/openssl tests passing at some point, but I think it makes more sense to circle back around to that once 10gen/openssl has its own evergreen project.

Evergreen patch showing successful compilation of the BI Connector on all platforms: https://evergreen.mongodb.com/version/5a4e3f602fbabe782e001f45