### PR TITLE
return dynamically linked openssl version

### DIFF
--- a/version.go
+++ b/version.go
@@ -16,7 +16,7 @@
 
 package openssl
 
-// #include <openssl/opensslv.h>
+// #include <openssl/crypto.h>
 import "C"
 
-const Version string = C.OPENSSL_VERSION_TEXT
+var Version string = C.GoString(C.SSLeay_version(C.SSLEAY_VERSION))


### PR DESCRIPTION
Right now, we return the version of openssl we used during build time - and not the one we actually have in use at runtime. This changes it so that the latter is returned.