### PR TITLE
Fix darwin compile/link omissions

### DIFF
--- a/build.go
+++ b/build.go
@@ -18,7 +18,8 @@ package openssl
 
 // #cgo linux darwin pkg-config: openssl
 // #cgo CFLAGS: -Wno-deprecated-declarations
+// #cgo darwin CFLAGS: -I/usr/local/opt/openssl/include
+// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl/lib -lssl -lcrypto -framework CoreFoundation -framework Foundation -framework Security
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN -I"c:/openssl/include"
 // #cgo windows LDFLAGS: -lssleay32 -llibeay32 -lcrypt32 -L "c:/openssl/bin"
-// #cgo darwin LDFLAGS: -framework CoreFoundation -framework Foundation -framework Security
 import "C"


### PR DESCRIPTION
This re-adds CFLAGS and LDFLAGS that were removed in https://github.com/10gen/openssl/commit/d3ffd1bcb61c9006de93d21614cac7630e75ca85.

Apple removed openssl headers so we have to explicitly tell the linker where to find them - pkg-config doesn't know (more on this [here](https://solitum.net/openssl-os-x-el-capitan-and-brew/)).